### PR TITLE
Removing min.js file from bower's main property 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,10 +3,7 @@
   "version": "0.0.6",
   "author": "Ninjatronic",
   "description": "AngularJS support for HTML5 Geolocation",
-  "main": [
-    "ngGeolocation.js",
-    "ngGeolocation.min.js"
-  ],
+  "main": "ngGeolocation.js",
   "ignore": [
     "bower_components/",
     "Gruntfile.js",


### PR DESCRIPTION
- Avoid having both the minified and non-minified files imported (see: [bower.json-spec](https://github.com/bower/bower.json-spec#main)) when using the library.