### PR TITLE
chore(build): list minified version in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "0.0.8",
   "author": "Ninjatronic",
   "description": "AngularJS support for HTML5 Geolocation",
-  "main": "ngGeolocation.js",
+  "license": "MIT",
+  "main": "ngGeolocation.min.js",
   "ignore": [
     "bower_components/",
     "Gruntfile.js",


### PR DESCRIPTION
Fix to use minified version by default when using bower in combination with tools like wiredep.
Fix License warnings in npm.
