### PR TITLE
Fix tests for phantomjs 1.x

### DIFF
--- a/jasmine.conf.js
+++ b/jasmine.conf.js
@@ -5,6 +5,7 @@ module.exports = function(config) {
         frameworks: ['jasmine'],
         plugins: ['karma-jasmine', 'karma-phantomjs-launcher'],
         files: [
+            'node_modules/phantomjs-polyfill/bind-polyfill.js',
             'bower_components/angular/angular.js',
             'bower_components/angular-mocks/angular-mocks.js',
             'ngGeolocation.min.js',

--- a/package.json
+++ b/package.json
@@ -4,17 +4,18 @@
     "bower": "~1.3.2",
     "grunt": "~0.4.4",
     "grunt-cli": "~0.1.13",
-    "phantomjs": "~1.9.7-3",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-concat": "~0.4.0",
+    "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-uglify": "~0.4.0",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-karma": "~0.8.2",
     "grunt-notify": "~0.2.20",
     "grunt-strip": "~0.2.1",
-    "grunt-karma": "~0.8.2",
     "karma": "~0.12.9",
     "karma-jasmine": "~0.1.5",
-    "karma-phantomjs-launcher": "~0.1.4"
+    "karma-phantomjs-launcher": "~0.1.4",
+    "phantomjs": "~1.9.7-3",
+    "phantomjs-polyfill": "0.0.2"
   },
   "scripts": {
     "postinstall": "./node_modules/.bin/bower install --dev",


### PR DESCRIPTION
Phantomjs 1.x requires polyfill for `bind()`

Add `phantomjs-polyfill` as travis ci currently does not support 2.x
